### PR TITLE
Add missing D, S, T descriptions to keyboard shortcuts

### DIFF
--- a/usage/keyboard-shortcuts.md
+++ b/usage/keyboard-shortcuts.md
@@ -17,6 +17,9 @@ FreeTube features a variety of keyboard shortcuts that you can use while watchin
 | C  | Turn subtitles on / off  |
 | O  | Decrease video speed by 0.25x |
 | P  | Increase video speed by 0.25x |
+| D  | Enter / Exit Picture in Picture Mode |
+| S  | Enter / Exit Full Window Mode |
+| T  | Enter / Exit Theatre Mode |
 | Up Arrow  | Increase Volume  |
 | Down Arrow  | Decrease Volume  |
 | Left Arrow  | Rewind 5 Seconds  |


### PR DESCRIPTION
This updates the docs with the missing keys that caused 2 issues (#1538, #1564) and adds the new [T] keybind for toggling theatre mode.