### PR TITLE
Remove ytdl-core and yt-dash-manifest-generator

### DIFF
--- a/credits.md
+++ b/credits.md
@@ -54,5 +54,3 @@ FreeTube uses the following modules / projects:
 | [vuex](https://github.com/vuejs/vuex)                                                          | MIT        |
 | [youtubei.js](https://github.com/LuanRT/YouTube.js)                                            | MIT        |
 | [yt-channel-info](https://github.com/FreeTubeApp/yt-channel-info)                              | ISC        |
-| [yt-dash-manifest-generator](https://github.com/FreeTubeApp/yt-dash-manifest-generator)        | GPLv3      |
-| [ytdl-core](https://github.com/fent/node-ytdl-core)                                            | MIT        |

--- a/usage/local-api.md
+++ b/usage/local-api.md
@@ -26,15 +26,13 @@ The Local API is one method of obtaining data from YouTube. For another method o
 
 ## Modules Used in the Local API
 
-| Name                                                                                     | License | Functionality                                            | Maintained By the FreeTube Team? |
-| ---------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------- | -------------------------------- |
-| [youtube-chat](https://github.com/FreeTubeApp/youtube-chat)                              | MIT     | Live Chat                                                | Yes                              |
-| [youtubei.js](https://github.com/LuanRT/YouTube.js)                                      | MIT     | Search Functionality + Suggestions, Playlists, Trending  | No                               |
-| [ytdl-core](https://github.com/fent/node-ytdl-core)                                      | MIT     | Obtain Video Information                                 | No                               |
-| [videojs-vtt-thumbnails-freetube](https://github.com/FreeTubeApp/videojs-vtt-thumbnails) | MIT     | Handle Video Thumbnails / Storyboards                    | Yes                              |
-| [yt-channel-info](https://github.com/FreeTubeApp/yt-channel-info)                        | ISC     | Channel Info / Search                                    | Yes                              |
-| [yt-comment-scraper](https://github.com/FreeTubeApp/yt-comment-scraper)                  | GPL-3.0 | Comment Info / Sort                                      | Yes                              |
-| [yt-dash-manifest-generator](https://github.com/FreeTubeApp/yt-dash-manifest-generator)  | GPL-3.0 | Generate DASH Files                                      | Yes                              |
+| Name                                                                                     | License | Functionality                                                                                          | Maintained By the FreeTube Team? |
+| ---------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| [youtube-chat](https://github.com/FreeTubeApp/youtube-chat)                              | MIT     | Live Chat                                                                                              | Yes                              |
+| [youtubei.js](https://github.com/LuanRT/YouTube.js)                                      | MIT     | Search Functionality + Suggestions, Playlists, Trending, Obtain Video Information, Generate DASH Files | No                               |
+| [videojs-vtt-thumbnails-freetube](https://github.com/FreeTubeApp/videojs-vtt-thumbnails) | MIT     | Handle Video Thumbnails / Storyboards                                                                  | Yes                              |
+| [yt-channel-info](https://github.com/FreeTubeApp/yt-channel-info)                        | ISC     | Channel Info / Search                                                                                  | Yes                              |
+| [yt-comment-scraper](https://github.com/FreeTubeApp/yt-comment-scraper)                  | GPL-3.0 | Comment Info / Sort                                                                                    | Yes                              |
 
 ## Fallback
 


### PR DESCRIPTION
https://github.com/FreeTubeApp/FreeTube/pull/3035

We might want to redesign this page at some point, as it will just be YouTube.js when the local API is fully migrated.

Also we should remove videojs-vtt-thumbnails-freetube from this page, as that is our video.js plugin to show the thumbnails when you hover over the progress bar, both the local and Invidious APIs provide those storyboards.