### PR TITLE
Correct maximum legacy formats resolution from 720p to 360p

### DIFF
--- a/usage/common-issues.md
+++ b/usage/common-issues.md
@@ -29,7 +29,7 @@ This is a limitation of the video player itself within FreeTube. The higher qual
 
 For more information, check out the [Video Formats](/usage/video-formats/#dash) page about DASH.
 
-## Videos Are Only Limited to 720p
+## Videos Are Only Limited to 360p
 
 Your video player is either set to use Legacy formats, or your video player is having issues with playing the DASH formats and reverting to legacy. If this is a continuous problem, please create an issue in the FreeTube repository and we can investigate this further.
 

--- a/usage/video-formats.md
+++ b/usage/video-formats.md
@@ -19,7 +19,7 @@ A current limitation is that videos will max out at 1080p. This is not a limitat
 
 Legacy formats are more of a term coined specifically for FreeTube. YouTube provides a small number of video streams that are traditional MP4 files with the video and audio combined and do not take advantage of DASH. These videos are labeled as "Legacy" videos within FreeTube.
 
-The main limitation of Legacy formats is that a legacy video will never have a quality above 720p.
+The main limitation of Legacy formats is that a legacy video will never have a quality above 360p.
 
 One benefit of the Legacy formats is that they are easier to play compared to DASH. Legacy formats use less resources and less bandwidth which makes them preferred for low spec devices like a Raspberry Pi.
 


### PR DESCRIPTION
YouTube removed the 720p legacy format stream, so there is only a 360p one.