### PR TITLE
Add a new extension to the list and small fixes

### DIFF
--- a/usage/browser-extension.md
+++ b/usage/browser-extension.md
@@ -5,12 +5,16 @@ parent: Usage
 permalink: /usage/browser-extension/
 ---
 
-FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings of the extension for it to work.
+FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to automatically open YouTube links in FreeTube. You must enable the option within the advanced settings of the extension for it to work.
 
-- Download Privacy Redirect for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-redirect/) or [Google Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb).
+- Download Privacy Redirect for [Firefox](https://addons.mozilla.org/firefox/addon/privacy-redirect/) or [Google Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb).
 
 - Download LibRedirect for [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) or [Google Chrome](https://libredirect.github.io/download_chromium.html).
 
+You can also use the [RedirectTube](https://github.com/MStankiewiczOfficial/RedirectTube) extension, which was created specifically to work with FreeTube. Unlike the above extensions, this one doesn't automatically open FreeTube when you open YouTube, but adds buttons on the toolbar and in the context menu, which when clicked open the video in FreeTube.
+
+- Download for [Firefox](https://addons.mozilla.org/firefox/addon/redirecttube/).
+
 If you have issues with the extension working with FreeTube, please create an issue in the [FreeTube Repository](https://github.com/FreeTubeApp/FreeTube) instead of the extension repository. Most if not all problems is a problem with FreeTube itself and not a problem with the extension.
 
-**This extension does not work on Linux portable builds!**
+**These extensions do not work on Linux portable builds!**


### PR DESCRIPTION
- Added the RedirectTube extension to the list.
- Added that Privacy Redirect and LibRedirect open FreeTube automatically when you open a link from YouTube.
- Fixed the Privacy Redirect link for Firefox so that it does not open the page in English, but in the browser language (as in the other links).
- In the warning about extensions not working on portable Linux builds, changed the singular to plural.