### PR TITLE
Fix typo on Local API page

### DIFF
--- a/usage/local-api.md
+++ b/usage/local-api.md
@@ -28,7 +28,7 @@ The Local API is one method of obtaining data from YouTube. For another method o
 
 | Name                                                | License | Maintained By the FreeTube Team? |
 | --------------------------------------------------- | ------- | -------------------------------- |
-| [youtubei.js](https://github.com/LuanRT/YouTube.js) | MIT     | No                               |
+| [youtube.js](https://github.com/LuanRT/YouTube.js)  | MIT     | No                               |
 
 ## Fallback
 


### PR DESCRIPTION
Minor fix: youtubei.js -> youtube.js