### PR TITLE
Add BgUtils to the local API page

### DIFF
--- a/usage/local-api.md
+++ b/usage/local-api.md
@@ -29,6 +29,7 @@ The Local API is one method of obtaining data from YouTube. For another method o
 | Name                                                | License | Maintained By the FreeTube Team? |
 | --------------------------------------------------- | ------- | -------------------------------- |
 | [youtubei.js](https://github.com/LuanRT/YouTube.js) | MIT     | No                               |
+| [bgutils-js](https://github.com/LuanRT/BgUtils)     | MIT     | No                               |
 
 ## Fallback
 


### PR DESCRIPTION
BgUtils is the library that we use to generate the proof of origin tokens in the local API.