### PR TITLE
Add googlevideo to the local API dependencies

### DIFF
--- a/credits.md
+++ b/credits.md
@@ -32,6 +32,7 @@ FreeTube uses the following modules / projects:
 | [autolinker](https://github.com/gregjacobs/Autolinker.js)                          | MIT        |
 | [bgutils-js](https://github.com/LuanRT/BgUtils)                                    | MIT        |
 | [electron-context-menu](https://github.com/sindresorhus/electron-context-menu)     | MIT        |
+| [googlevideo](https://github.com/LuanRT/googlevideo)                               | MIT        |
 | [marked](https://github.com/markedjs/marked)                                       | MIT        |
 | [path-browserify](https://github.com/browserify/path-browserify)                   | MIT        |
 | [portal-vue](https://github.com/LinusBorg/portal-vue)                              | MIT        |

--- a/usage/local-api.md
+++ b/usage/local-api.md
@@ -26,10 +26,11 @@ The Local API is one method of obtaining data from YouTube. For another method o
 
 ## Modules Used in the Local API
 
-| Name                                                | License | Maintained By the FreeTube Team? |
-| --------------------------------------------------- | ------- | -------------------------------- |
-| [youtubei.js](https://github.com/LuanRT/YouTube.js) | MIT     | No                               |
-| [bgutils-js](https://github.com/LuanRT/BgUtils)     | MIT     | No                               |
+| Name                                                 | License | Maintained By the FreeTube Team? |
+| ---------------------------------------------------- | ------- | -------------------------------- |
+| [youtubei.js](https://github.com/LuanRT/YouTube.js)  | MIT     | No                               |
+| [bgutils-js](https://github.com/LuanRT/BgUtils)      | MIT     | No                               |
+| [googlevideo](https://github.com/LuanRT/googlevideo) | MIT     | No                               |
 
 ## Fallback
 


### PR DESCRIPTION
In draft status until https://github.com/FreeTubeApp/FreeTube/pull/7145 is ready (still in draft status itself at the time of writing) and has been merged.