### PR TITLE
Add community page

### DIFF
--- a/community/community.md
+++ b/community/community.md
@@ -4,28 +4,3 @@ title: Community
 has_children: true
 permalink: /community/
 ---
-
-## Welcome to the FreeTube community!
-
-First of all, we want to say thank you for getting involved in the project!
-
-This page provides guidelines on how to engage respectfully when contributing to or interacting with the FreeTube project, its maintainers, and the surrounding community.
-
-## Rules
-
-- We reserve the right to modify or update these rules as necessary.
-- Please use English for all communication. Language barriers can make it difficult for others to understand and contribute effectively.
-- Please keep in mind that FreeTube is a FLOSS project driven entirely by volunteers. All development work is done on a voluntary basis during contributors' spare time. We kindly ask that you respect their efforts and refrain from inquiring about specific timelines for feature releases or bug fixes. As a community-driven project, we are unable to provide detailed schedules or make promises regarding future updates.
-- Please act appropriately. Should you be unsure what this means, [GitHub's Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines) might help you.
-- Please refrain from using AI/LLMs to create issues, pull requests, comments, or any other content submitted to the FreeTube project.
-- If you are ever unsure of something, feel free to contact a member of the team via the [Matrix chatroom](/community/matrix).
-
-## Moderation policy
-
-If you violate the rules outlined above, such as by insulting others in the FreeTube community or spamming issues, we will take appropriate moderation actions.
-
-Initially, you will receive a written warning from a member of the FreeTube team. They will ask you to cease the behavior and refrain from repeating it in the future. In some cases, they may also delete the content that led to the warning.
-
-If you persist with the inappropriate behavior or engage in any other form of misconduct, there will be no second warning. You will be permanently banned from contributing to the FreeTube project.
-
-Please note that this policy may not apply uniformly to every situation. Moderators may determine that a stricter approach is necessary, such as in cases of spammy behavior on GitHub, which could result in an immediate ban without prior warning.

--- a/community/matrix.md
+++ b/community/matrix.md
@@ -24,6 +24,6 @@ Once you have an account, you can [join the chatroom here.](https://matrix.to/#/
 
 ## Rules
 
-- General rules for participating in the FreeTube project can be found on the [Community](/community) page.
+- General rules for participating in the FreeTube project can be found on the [Rules](/community/rules) page.
 - Do not ask for anyone's personal information. This is a privacy focused community and we should respect each other's privacy.
 - Please keep the discussion related to FreeTube. General privacy discussion is also okay, but if it starts to become a heated debate, consider continuing the debate in a different chatroom for the sake of the other users.

--- a/community/rules.md
+++ b/community/rules.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: Rules
+parent: Community
+permalink: /community/rules/
+---
+
+This page provides guidelines on how to engage respectfully when contributing to or interacting with the FreeTube project, its maintainers, and the surrounding community.
+
+## Rules
+
+- We reserve the right to modify or update these rules as necessary.
+- Please use English for all communication. Language barriers can make it difficult for others to understand and contribute effectively.
+- Please keep in mind that FreeTube is a FLOSS project driven entirely by volunteers. All development work is done on a voluntary basis during contributors' spare time. We kindly ask that you respect their efforts and refrain from inquiring about specific timelines for feature releases or bug fixes. As a community-driven project, we are unable to provide detailed schedules or make promises regarding future updates.
+- Please act appropriately. Should you be unsure what this means, [GitHub's Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines) might help you.
+- Please refrain from using AI/LLMs to create issues, pull requests, comments, or any other content submitted to the FreeTube project.
+- If you are ever unsure of something, feel free to contact a member of the team via the [Matrix chatroom](/community/matrix).
+
+## Moderation policy
+
+If you violate the rules outlined above, such as by insulting others in the FreeTube community or spamming issues, we will take appropriate moderation actions.
+
+Initially, you will receive a written warning from a member of the FreeTube team. They will ask you to cease the behavior and refrain from repeating it in the future. In some cases, they may also delete the content that led to the warning.
+
+If you persist with the inappropriate behavior or engage in any other form of misconduct, there will be no second warning. You will be permanently banned from contributing to the FreeTube project.
+
+Please note that this policy may not apply uniformly to every situation. Moderators may determine that a stricter approach is necessary, such as in cases of spammy behavior on GitHub, which could result in an immediate ban without prior warning.


### PR DESCRIPTION
This PR adds a dedicated community page on which contributors can find rules and the moderation policy.
The rules which could be found on the Matrix page before, have been moved to the new page, adopted, and removed from the Matrix page. 

Should you have any change requests, just let me know!