### PR TITLE
Update build command for ARM64 binaries

### DIFF
--- a/development/building-from-source.md
+++ b/development/building-from-source.md
@@ -28,7 +28,7 @@ Once the command has finished, a new `build/` folder will be created in the proj
 If you are running a 64 bit Linux OS, you will also be able to create ARM64 binaries. To do so, run the following command:
 
 ```
-yarn run build:arm
+yarn run build:arm64
 ```
 
 Binaries will be located in the same location as the other command.


### PR DESCRIPTION
The code uses arm64 instead of arm so I changed it in the documentation.