### PR TITLE
Sync GitHub Actions improvements from main repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     labels:
       - "PR: waiting for review"
       - "PR: dependencies"
+    groups:
+      "github/codeql-action":
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -1,17 +1,21 @@
 name: Auto Merge PR
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, auto_merge_disabled, ready_for_review]
+
+permissions: {}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.state == 'open' &&
+      !github.event.pull_request.draft &&
+      contains(github.event.pull_request.base.ref, 'master')
+    runs-on: ubuntu-slim
 
     steps:
     - name: Auto Merge PR
-      if: contains(${{ github.event.pull_request.base.ref }}, 'master')
-      run: |
-        echo ${{ secrets.GH_TOKEN }} >> auth.txt
-        gh auth login --with-token < auth.txt
-        rm auth.txt
-        gh pr merge https://github.com/FreeTubeApp/FreeTube-Docs/pull/${{ github.event.pull_request.number }} --auto --squash
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      run: gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -5,22 +5,38 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
+
+permissions: {}
+
 jobs:
   build:
+    # As this action runs on a schedule, only run it in the FreeTubeApp/FreeTube-Docs repository to avoid unnecessary GitHub Actions usage/billing in forks.
+    # Still allow the workflow to be manually triggered.
+    # If a fork does need this workflow, they can change this condition in their fork to include their repository.
+    if: github.repository == 'FreeTubeApp/FreeTube-Docs' || github.event_name == 'workflow_dispatch'
+
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@9d037c06280028c110ff61c433ad4dc7d33c3c43
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
       - name: Create New Pull Request If Needed
         if: steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           title: Compressed Images Nightly
           branch-suffix: timestamp

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,10 +9,18 @@ on:
   schedule:
     - cron: '18 17 * * 4'
 
+permissions: {}
+
 jobs:
   analyze:
-    name: Analyze
+    # As this action runs on a schedule, only run it in the FreeTubeApp/FreeTube-Docs repository to avoid unnecessary GitHub Actions usage/billing in forks.
+    # We still allow it to run if it was triggered by a pull request or a push as active forks should care about security.
+    # If a fork does need this workflow to run on a schedule, they can change this condition in their fork to include their repository.
+    if: github.repository == 'FreeTubeApp/FreeTube-Docs' || github.event_name != 'schedule'
+
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+
     permissions:
       actions: read
       contents: read
@@ -21,43 +29,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'ruby' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        include:
+          - language: actions
+            build-mode: none
+          - language: ruby
+            build-mode: none
+          # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+      with:
+        persist-credentials: false
 
-    # Initializes the CodeQL tools for scanning.
+
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+        build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -8,12 +8,23 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
-    runs-on: ubuntu-latest
+    name: Check for conflicts
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
       - name: check if prs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 #v3.1.0
         with:
           dirtyLabel: "PR: merge conflicts / rebase needed"
           removeOnDirtyLabel: "PR: waiting for review"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -3,15 +3,18 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
+permissions: {}
+
 jobs:
   triage:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+
+    runs-on: ubuntu-slim
     if: ${{ !github.event.pull_request.draft }}
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d #v6.2.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/pr-labeler.yml

--- a/.github/workflows/remove-outdated-labels.yml
+++ b/.github/workflows/remove-outdated-labels.yml
@@ -5,57 +5,66 @@ on:
       - closed
       - converted_to_draft
       - ready_for_review
-jobs:
-  remove-merged-pr-labels:
-    name: Remove merged pull request labels
-    if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: waiting for review
-            PR: WIP
-            PR: changes requested
-            PR: merge conflicts / rebase needed
-            PR/Issue: dependent
-            PR: stale
 
+permissions: {}
+
+jobs:
   remove-closed-pr-labels:
-    name: Remove closed pull request labels
-    if: github.event_name == 'pull_request_target' && (! github.event.pull_request.merged) && (github.event.action != 'converted_to_draft') && (github.event.action != 'ready_for_review')
-    runs-on: ubuntu-latest
+    name: Remove closed and merged pull request labels
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: waiting for review
-            PR: WIP
-            PR: changes requested
-            PR: merge conflicts / rebase needed
-            PR/Issue: dependent
-            PR: stale
+      - name: Remove labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          labels='PR: waiting for review,'
+          labels+='PR: WIP,'
+          labels+='PR: changes requested,'
+          labels+='PR: merge conflicts / rebase needed,'
+          labels+='PR/Issue: dependent,'
+          labels+='PR: stale'
+
+          gh pr edit "$PR_URL" --remove-label "$labels"
 
   remove-draft-pr-labels:
     name: Remove labels from draft pull requests
-    if: github.event_name == 'pull_request_target' && github.event.action == 'converted_to_draft'
-    runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'converted_to_draft' && contains(github.event.pull_request.labels.*.name, 'PR: waiting for review')
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: waiting for review
-            
+      - name: Remove label
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --remove-label 'PR: waiting for review'
+
   remove-ready-pr-labels:
     name: Remove labels when draft pr is marked ready for review
-    if: github.event_name == 'pull_request_target' && github.event.action == 'ready_for_review'
-    runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'PR: WIP')
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: WIP
+      - name: Remove label
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --remove-label 'PR: WIP'


### PR DESCRIPTION
List of changes:
- Limit GITHUB_TOKEN permissions to the ones that are actually required and disable persisting credentials in the checkout action
- Pin Action versions
- Update the CodeQL workflow steps and add scanning for GitHub Actions
- Add a dependabot group for the codeql actions
- Run some workflows on ubuntu-slim
- Switch the remove labels workflow to `gh pr edit --remove-label`
- Add the concurrency controls to the conflicts workflow (probably not needed in this repo but keeping for parity)
- Don't run scheduled workflows in forks by default